### PR TITLE
Add dark theme toggle with persistent preferences

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>BUTTS IN SEATS</title>
+    <link rel="stylesheet" href="style.css">
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap');
         
@@ -15,15 +16,15 @@
 
         body {
             font-family: 'Inter', -apple-system, system-ui, sans-serif;
-            background: #0052cc;
-            color: #fff;
+            background: var(--bg-color);
+            color: var(--text-color);
             min-height: 100vh;
             overflow-x: hidden;
         }
 
         .main-screen {
             min-height: 100vh;
-            background: #0052cc;
+            background: var(--bg-color);
             display: flex;
             flex-direction: column;
             position: relative;
@@ -40,7 +41,7 @@
         .intro-text {
             font-size: clamp(2rem, 4vw, 4rem);
             font-weight: 900;
-            color: #fff;
+            color: var(--text-color);
             text-transform: uppercase;
             letter-spacing: -0.03em;
             opacity: 0.7;
@@ -59,7 +60,7 @@
             font-size: clamp(6rem, 16vw, 16rem);
             font-weight: 900;
             line-height: 0.8;
-            color: #fff;
+            color: var(--text-color);
             margin-bottom: 16px;
             letter-spacing: -0.03em;
         }
@@ -67,21 +68,21 @@
         .stat-label {
             font-size: clamp(2rem, 4vw, 4rem);
             font-weight: 900;
-            color: #fff;
+            color: var(--text-color);
             text-transform: uppercase;
             letter-spacing: -0.03em;
             opacity: 0.7;
         }
 
         .comparison-section {
-            background: #003d99;
+            background: var(--bg-alt);
             padding: 80px 40px;
         }
 
         .comparison-intro {
             font-size: clamp(1.5rem, 3vw, 3rem);
             font-weight: 900;
-            color: #fff;
+            color: var(--text-color);
             text-transform: uppercase;
             letter-spacing: -0.03em;
             opacity: 0.7;
@@ -93,8 +94,8 @@
         }
 
         .year-selector select {
-            background: #fff;
-            color: #003d99;
+            background: var(--select-bg);
+            color: var(--accent-color);
             border: none;
             padding: 12px 40px 12px 16px;
             font-size: clamp(1.5rem, 3vw, 3rem);
@@ -122,7 +123,7 @@
             font-size: clamp(3rem, 8vw, 8rem);
             font-weight: 900;
             line-height: 0.8;
-            color: #fff;
+            color: var(--text-color);
             margin-bottom: 12px;
             letter-spacing: -0.03em;
         }
@@ -130,23 +131,23 @@
         .historical-label {
             font-size: clamp(1.2rem, 2.5vw, 2.5rem);
             font-weight: 900;
-            color: #fff;
+            color: var(--text-color);
             text-transform: uppercase;
             letter-spacing: -0.03em;
             opacity: 0.6;
         }
 
         .metadata {
-            background: #001a66;
+            background: var(--bg-metadata);
             padding: 40px;
             font-size: 1rem;
-            color: #fff;
+            color: var(--text-color);
             text-align: center;
             opacity: 0.8;
         }
 
         .metadata a {
-            color: #fff;
+            color: var(--text-color);
             text-decoration: none;
             font-weight: 700;
         }
@@ -157,27 +158,41 @@
             left: 0;
             width: 100%;
             height: 100%;
-            background: #0052cc;
+            background: var(--bg-color);
             display: flex;
             align-items: center;
             justify-content: center;
             font-size: clamp(2rem, 6vw, 6rem);
             font-weight: 900;
-            color: #fff;
+            color: var(--text-color);
             text-transform: uppercase;
             letter-spacing: -0.03em;
             text-align: center;
         }
 
         .error {
-            background: #fff;
-            color: #0052cc;
+            background: var(--text-color);
+            color: var(--bg-color);
             padding: 40px;
             text-align: center;
             font-size: 2rem;
             font-weight: 900;
             text-transform: uppercase;
             letter-spacing: -0.03em;
+        }
+
+        .theme-toggle {
+            position: fixed;
+            top: 20px;
+            right: 20px;
+            background: var(--text-color);
+            color: var(--bg-color);
+            border: none;
+            padding: 10px 16px;
+            cursor: pointer;
+            font-weight: 600;
+            border-radius: 4px;
+            z-index: 1000;
         }
 
         @media (max-width: 768px) {
@@ -204,6 +219,7 @@
     </style>
 </head>
 <body>
+    <button id="theme-toggle" class="theme-toggle">Toggle Theme</button>
     <div id="loading" class="loading">LOADING BROADWAY DATA...</div>
     <div id="error" class="error" style="display: none;"></div>
     
@@ -463,6 +479,19 @@
         }
 
         document.addEventListener('DOMContentLoaded', () => {
+            const savedTheme = localStorage.getItem('theme');
+            if (savedTheme) {
+                document.documentElement.setAttribute('data-theme', savedTheme);
+            }
+
+            const toggle = document.getElementById('theme-toggle');
+            toggle.addEventListener('click', () => {
+                const current = document.documentElement.getAttribute('data-theme');
+                const next = current === 'dark' ? 'light' : 'dark';
+                document.documentElement.setAttribute('data-theme', next);
+                localStorage.setItem('theme', next);
+            });
+
             new BroadwayDashboard();
         });
     </script>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,17 @@
+:root {
+  --bg-color: #0052cc;
+  --bg-alt: #003d99;
+  --bg-metadata: #001a66;
+  --text-color: #ffffff;
+  --accent-color: #003d99;
+  --select-bg: #ffffff;
+}
+
+[data-theme='dark'] {
+  --bg-color: #0d1117;
+  --bg-alt: #161b22;
+  --bg-metadata: #010409;
+  --text-color: #e6edf3;
+  --accent-color: #58a6ff;
+  --select-bg: #0d1117;
+}


### PR DESCRIPTION
## Summary
- define CSS variables and dark theme alternatives in `style.css`
- add theme toggle button with script to switch themes and store preference
- apply color variables across index for dynamic theming

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b51bba9584832aae34baf725474f45