### PR TITLE
Improve responsive padding for small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,28 +180,8 @@
             letter-spacing: -0.03em;
         }
 
-        @media (max-width: 768px) {
-            .data-section {
-                padding: 60px 20px;
-            }
-            
-            .comparison-section {
-                padding: 60px 20px;
-            }
-            
-            .stat-item {
-                margin-bottom: 40px;
-            }
-
-            .historical-stat {
-                margin-bottom: 30px;
-            }
-
-            .year-selector {
-                margin-left: 12px;
-            }
-        }
     </style>
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <div id="loading" class="loading">LOADING BROADWAY DATA...</div>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,38 @@
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .data-section,
+  .comparison-section {
+    padding: 40px 20px;
+  }
+
+  .stat-item {
+    margin-bottom: 30px;
+  }
+
+  .historical-stat {
+    margin-bottom: 20px;
+  }
+
+  .year-selector {
+    margin-left: 8px;
+  }
+}
+
+@media (max-width: 480px) {
+  .data-section,
+  .comparison-section {
+    padding: 30px 10px;
+  }
+
+  .stat-item {
+    margin-bottom: 20px;
+  }
+
+  .historical-stat {
+    margin-bottom: 15px;
+  }
+
+  .year-selector {
+    margin-left: 4px;
+  }
+}


### PR DESCRIPTION
## Summary
- Move mobile styles into a dedicated `style.css` file and link it from `index.html`
- Tighten `@media (max-width: 768px)` spacing for data and comparison sections
- Add new `@media (max-width: 480px)` breakpoint for extra-small screens

## Testing
- ❌ `npm install playwright` *(403 Forbidden: unable to install Playwright to run viewport tests)*
- ✅ `node -e "const fs=require('fs'); const html=fs.readFileSync('index.html','utf8'); console.log(/overflow-x:\s*hidden/.test(html));"`


------
https://chatgpt.com/codex/tasks/task_e_68b51bb91174832ab0b01cb30e9759f8