### PR TITLE
feat: restore original dashboard layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,48 +5,47 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>BUTTS IN SEATS</title>
 
-  <!-- Fonts & styles -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
-    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap"
     rel="stylesheet"
   />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <main class="main-screen">
-    <!-- Current-week data -->
-    <section class="data-section">
-      <h1 class="intro-text">Butts in Seats</h1>
+  <div id="loading" class="loading">LOADING BROADWAY DATA...</div>
+  <div id="error" class="error" hidden></div>
 
-      <p id="loading">Loading Broadway stats…</p>
-      <p id="error" role="alert" hidden></p>
+  <div id="dashboard" hidden>
+    <div class="main-screen">
+      <section class="data-section">
+        <p class="intro-text">LAST WEEK THERE WERE</p>
 
-      <div id="dashboard" hidden class="main-stats">
-        <div class="stat-item">
-          <p id="attendance" class="stat-number">0</p>
-          <p class="stat-label">Attendance</p>
+        <div class="main-stats">
+          <div class="stat-item">
+            <p id="attendance" class="stat-number">-</p>
+            <p class="stat-label">BUTTS IN</p>
+          </div>
+          <div class="stat-item">
+            <p id="capacity" class="stat-number">-</p>
+            <p class="stat-label">SEATS</p>
+          </div>
+          <div class="stat-item">
+            <p id="percentage" class="stat-number">-</p>
+            <p class="stat-label">FILLED</p>
+          </div>
         </div>
-        <div class="stat-item">
-          <p id="capacity" class="stat-number">0</p>
-          <p class="stat-label">Capacity</p>
-        </div>
-        <div class="stat-item">
-          <p id="percentage" class="stat-number">0%</p>
-          <p class="stat-label">Fill Rate</p>
-        </div>
-      </div>
-    </section>
+      </section>
+    </div>
 
-    <!-- Historical comparison -->
     <section class="comparison-section">
       <p class="comparison-intro">
-        Compare to previous years
+        THIS WEEK IN
         <span class="year-selector">
           <label for="year-select" class="sr-only">Select year</label>
           <select id="year-select">
-            <option value="2024" selected>2024</option>
+            <option value="2024">2024</option>
             <option value="2023">2023</option>
             <option value="2022">2022</option>
             <option value="2021">2021</option>
@@ -62,27 +61,35 @@
 
       <div class="historical-stats">
         <div class="historical-stat">
-          <p id="historical-attendance" class="historical-number">0</p>
-          <p class="historical-label">Attendance</p>
+          <p id="historical-attendance" class="historical-number">-</p>
+          <p class="historical-label">BUTTS IN</p>
         </div>
         <div class="historical-stat">
-          <p id="historical-capacity" class="historical-number">0</p>
-          <p class="historical-label">Capacity</p>
+          <p id="historical-capacity" class="historical-number">-</p>
+          <p class="historical-label">SEATS</p>
         </div>
         <div class="historical-stat">
-          <p id="historical-percentage" class="historical-number">0%</p>
-          <p class="historical-label">Fill Rate</p>
+          <p id="historical-percentage" class="historical-number">-</p>
+          <p class="historical-label">FILLED</p>
         </div>
       </div>
     </section>
 
-    <!-- Metadata & theme toggle -->
     <footer class="metadata">
-      <p id="week-ending"></p>
-      <p id="last-updated"></p>
+      <p id="week-ending">Week ending: -</p>
+      <p id="last-updated">Last updated: -</p>
+      <p>
+        Data source:
+        <a
+          href="https://www.broadwayworld.com/grosses.cfm"
+          target="_blank"
+          rel="noopener noreferrer"
+          >BROADWAYWORLD</a
+        >
+      </p>
       <button id="theme-toggle" aria-label="Toggle dark theme">🌓</button>
     </footer>
-  </main>
+  </div>
 
   <script>
     class BroadwayDashboard {
@@ -99,7 +106,6 @@
       async loadCurrentData() {
         try {
           const res = await fetch("/.netlify/functions/broadway-data");
-          if (!res.ok) throw new Error("Network response was not ok");
           const data = await res.json();
 
           document.getElementById("attendance").textContent =
@@ -121,11 +127,11 @@
       }
 
       setupYearSelector() {
-        const select = document.getElementById("year-select");
-        select.addEventListener("change", (e) =>
-          this.loadHistoricalData(e.target.value)
-        );
-        this.loadHistoricalData(select.value);
+      const select = document.getElementById("year-select");
+      select.addEventListener("change", (e) =>
+        this.loadHistoricalData(e.target.value)
+      );
+      this.loadHistoricalData(select.value);
       }
 
       async loadHistoricalData(year) {
@@ -170,16 +176,14 @@
       }
 
       showError(message) {
+        document.getElementById("loading").hidden = true;
         const err = document.getElementById("error");
         err.textContent = message;
         err.hidden = false;
-        document.getElementById("loading").hidden = true;
       }
     }
 
-    document.addEventListener("DOMContentLoaded", () => {
-      new BroadwayDashboard();
-    });
+    document.addEventListener("DOMContentLoaded", () => new BroadwayDashboard());
   </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,17 +1,217 @@
 :root {
-  --bg-color: #0052cc;
-  --bg-alt: #003d99;
-  --bg-metadata: #001a66;
-  --text-color: #ffffff;
-  --accent-color: #003d99;
-  --select-bg: #ffffff;
+  --blue: #0052cc;
+  --blue-dark: #003d99;
+  --blue-darker: #001a66;
+  --text: #fff;
 }
 
-[data-theme='dark'] {
-  --bg-color: #0d1117;
-  --bg-alt: #161b22;
-  --bg-metadata: #010409;
-  --text-color: #e6edf3;
-  --accent-color: #58a6ff;
-  --select-bg: #0d1117;
+[data-theme="dark"] {
+  --blue: #0d1117;
+  --blue-dark: #161b22;
+  --blue-darker: #010409;
+  --text: #e6edf3;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: "Inter", -apple-system, system-ui, sans-serif;
+  background: var(--blue);
+  color: var(--text);
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+.main-screen {
+  min-height: 100vh;
+  background: var(--blue);
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.data-section {
+  flex: 1;
+  padding: 80px 40px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.intro-text {
+  font-size: clamp(2rem, 4vw, 4rem);
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: -0.03em;
+  opacity: 0.7;
+  margin-bottom: 60px;
+}
+
+.main-stats {
+  margin-bottom: 60px;
+}
+
+.stat-item {
+  margin-bottom: 60px;
+}
+
+.stat-number {
+  font-size: clamp(6rem, 16vw, 16rem);
+  font-weight: 900;
+  line-height: 0.8;
+  margin-bottom: 16px;
+  letter-spacing: -0.03em;
+}
+
+.stat-label {
+  font-size: clamp(2rem, 4vw, 4rem);
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: -0.03em;
+  opacity: 0.7;
+}
+
+.comparison-section {
+  background: var(--blue-dark);
+  padding: 80px 40px;
+}
+
+.comparison-intro {
+  font-size: clamp(1.5rem, 3vw, 3rem);
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: -0.03em;
+  opacity: 0.7;
+  margin-bottom: 60px;
+}
+
+.year-selector {
+  margin-left: 20px;
+}
+
+.year-selector select {
+  background: #fff;
+  color: var(--blue-dark);
+  border: none;
+  padding: 12px 40px 12px 16px;
+  font-size: clamp(1.5rem, 3vw, 3rem);
+  font-weight: 900;
+  font-family: inherit;
+  text-transform: uppercase;
+  cursor: pointer;
+  letter-spacing: -0.03em;
+  appearance: none;
+  background-image: url("data:image/svg+xml;charset=US-ASCII,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'><path fill='%23003d99' d='M2 0L0 2h4zm0 5L0 3h4z'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 16px center;
+  background-size: 12px;
+}
+
+.historical-stats {
+  margin-top: 0;
+}
+
+.historical-stat {
+  margin-bottom: 40px;
+}
+
+.historical-number {
+  font-size: clamp(3rem, 8vw, 8rem);
+  font-weight: 900;
+  line-height: 0.8;
+  margin-bottom: 12px;
+  letter-spacing: -0.03em;
+}
+
+.historical-label {
+  font-size: clamp(1.2rem, 2.5vw, 2.5rem);
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: -0.03em;
+  opacity: 0.6;
+}
+
+.metadata {
+  background: var(--blue-darker);
+  padding: 40px;
+  font-size: 1rem;
+  text-align: center;
+  opacity: 0.8;
+}
+
+.metadata a {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 700;
+}
+
+#theme-toggle {
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.5rem;
+}
+
+.loading {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--blue);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(2rem, 6vw, 6rem);
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: -0.03em;
+  text-align: center;
+}
+
+.error {
+  background: #fff;
+  color: var(--blue);
+  padding: 40px;
+  text-align: center;
+  font-size: 2rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: -0.03em;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 768px) {
+  .data-section,
+  .comparison-section {
+    padding: 60px 20px;
+  }
+
+  .stat-item {
+    margin-bottom: 40px;
+  }
+
+  .historical-stat {
+    margin-bottom: 30px;
+  }
+
+  .year-selector {
+    margin-left: 12px;
+  }
 }


### PR DESCRIPTION
## Summary
- restore original dashboard layout and typography
- keep historical comparison and add accessible year selector
- support light/dark themes with toggle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b52113bc00832a878c7394c64c9f41