### PR TITLE
Clarify percentage label for filled seats

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
           </div>
           <div class="stat-item">
             <p id="percentage" class="stat-number">-</p>
-            <p class="stat-label">FILLED</p>
+            <p class="stat-label">OF SEATS<br />WERE FILLED.</p>
           </div>
         </div>
       </section>
@@ -86,7 +86,7 @@
         </div>
         <div class="historical-stat">
           <p id="historical-percentage" class="historical-number">-</p>
-          <p class="historical-label">FILLED</p>
+          <p class="historical-label">OF SEATS<br />WERE FILLED.</p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- clarify percentage label so main and historical stats read "OF SEATS WERE FILLED."
- add line breaks for the longer label text

## Testing
- `npm test` *(fails: ENOENT open /workspace/butts-dashboard/package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b53c23a750832aa725ce1cd7ea6316