### PR TITLE
Make intro text dynamic based on show count

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
   <div id="dashboard" hidden>
     <div class="main-screen">
       <section class="data-section">
-        <p class="intro-text">LAST WEEK THERE WERE</p>
+        <p id="intro-text" class="intro-text"></p>
 
         <div class="main-stats">
           <div class="stat-item">
@@ -141,6 +141,8 @@
             data.percentage + "%";
           document.getElementById("shows-running").textContent =
             data.showCount.toLocaleString();
+          document.getElementById("intro-text").textContent =
+            `LAST WEEK THERE WERE ${data.showCount.toLocaleString()} SHOWS RUNNING`;
           document.getElementById("week-ending").textContent =
             "Week ending: " + data.weekEnding;
           document.getElementById("last-updated").textContent =
@@ -185,6 +187,8 @@
           mockData.percentage + "%";
         document.getElementById("shows-running").textContent =
           mockData.showCount.toLocaleString();
+        document.getElementById("intro-text").textContent =
+          `LAST WEEK THERE WERE ${mockData.showCount.toLocaleString()} SHOWS RUNNING`;
         document.getElementById("week-ending").textContent =
           "Week ending: " + mockData.weekEnding;
         document.getElementById("last-updated").textContent =


### PR DESCRIPTION
## Summary
- Convert intro text into an element that can be updated dynamically.
- Display last week's show count directly in intro text when current or mock data loads.

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b53ea72178832a946346332581db36