### PR TITLE
Make intro text dynamic based on show count

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
   <div id="dashboard" hidden>
     <div class="main-screen">
       <section class="data-section">
-        <p class="intro-text">LAST WEEK THERE WERE</p>
+        <p id="intro-text" class="intro-text"></p>
 
         <div class="main-stats">
           <div class="stat-item">
@@ -141,6 +141,8 @@
             data.percentage + "%";
           document.getElementById("shows-running").textContent =
             data.showCount.toLocaleString();
+          document.getElementById("intro-text").innerHTML =
+            `<span class="intro-faded">LAST WEEK THERE WERE</span><br>${data.showCount.toLocaleString()} SHOWS <span class="intro-faded">RUNNING</span>`;
           document.getElementById("week-ending").textContent =
             "Week ending: " + data.weekEnding;
           document.getElementById("last-updated").textContent =
@@ -185,6 +187,8 @@
           mockData.percentage + "%";
         document.getElementById("shows-running").textContent =
           mockData.showCount.toLocaleString();
+        document.getElementById("intro-text").innerHTML =
+          `<span class="intro-faded">LAST WEEK THERE WERE</span><br>${mockData.showCount.toLocaleString()} SHOWS <span class="intro-faded">RUNNING</span>`;
         document.getElementById("week-ending").textContent =
           "Week ending: " + mockData.weekEnding;
         document.getElementById("last-updated").textContent =

--- a/style.css
+++ b/style.css
@@ -47,8 +47,12 @@ body {
   font-weight: 900;
   text-transform: uppercase;
   letter-spacing: -0.03em;
-  opacity: 0.7;
+  line-height: 1.1;
   margin-bottom: 60px;
+}
+
+.intro-faded {
+  opacity: 0.7;
 }
 
 .main-stats {


### PR DESCRIPTION
## Summary
- Break intro text into two lines and fade supporting words
- Highlight weekly show count in white with tighter spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b53ea72178832a946346332581db36