### PR TITLE
Remove "IN" from current and historical labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         <div class="main-stats">
           <div class="stat-item">
             <p id="attendance" class="stat-number">-</p>
-            <p class="stat-label">BUTTS IN</p>
+            <p class="stat-label">BUTTS</p>
           </div>
           <div class="stat-item">
             <p id="capacity" class="stat-number">-</p>
@@ -60,7 +60,7 @@
       <div class="historical-stats">
         <div class="historical-stat">
           <p id="historical-attendance" class="historical-number">-</p>
-          <p class="historical-label">BUTTS IN</p>
+          <p class="historical-label">BUTTS</p>
         </div>
         <div class="historical-stat">
           <p id="historical-capacity" class="historical-number">-</p>


### PR DESCRIPTION
## Summary
- Drop "IN" from current attendance label so it reads "BUTTS"
- Drop "IN" from historical attendance label for cleaner text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8caa3cb74832aaf7b4301439961ce