### PR TITLE
Remove redundant attendance displays

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,12 +22,6 @@
       <section class="data-section">
         <p id="intro-text" class="intro-text"></p>
 
-        <div class="main-stats">
-          <div class="stat-item">
-            <p id="attendance" class="stat-number">-</p>
-            <p class="stat-label">BUTTS IN SEATS</p>
-          </div>
-        </div>
       </section>
     </div>
 
@@ -50,12 +44,6 @@
       
 
 
-      <div class="historical-stats">
-        <div class="historical-stat">
-          <p id="historical-attendance" class="historical-number">-</p>
-          <p class="historical-label">BUTTS IN SEATS</p>
-        </div>
-      </div>
     </section>
 
     <footer class="metadata">
@@ -91,9 +79,6 @@
         try {
           const res = await fetch("/.netlify/functions/broadway-data");
           const data = await res.json();
-
-          document.getElementById("attendance").textContent =
-            data.attendance.toLocaleString();
 
           document.getElementById("intro-text").innerHTML =
             `<span class="intro-faded">LAST WEEK THERE WERE</span> ` +
@@ -139,9 +124,6 @@
             timeZone: 'America/New_York'
           })
         };
-
-        document.getElementById("attendance").textContent =
-          mockData.attendance.toLocaleString();
 
         document.getElementById("intro-text").innerHTML =
           `<span class="intro-faded">LAST WEEK THERE WERE</span> ` +
@@ -215,8 +197,6 @@
           );
           const data = await res.json();
 
-          document.getElementById("historical-attendance").textContent =
-            data.attendance.toLocaleString();
           document.getElementById("historical-shows-display").textContent =
             data.showCount.toLocaleString();
         } catch (err) {
@@ -276,8 +256,6 @@
 
         console.log("Mock data calculated:", mockData);
 
-        document.getElementById("historical-attendance").textContent =
-          mockData.attendance.toLocaleString();
         document.getElementById("historical-shows-display").textContent =
           mockData.showCount.toLocaleString();
 

--- a/style.css
+++ b/style.css
@@ -61,29 +61,6 @@ body {
   opacity: 1;
 }
 
-.main-stats { }
-
-.stat-item { margin-bottom: 50px; }
-.stat-item:last-child { margin-bottom: 0; }
-
-.stat-number {
-  font-size: clamp(6rem, 16vw, 16rem);
-  font-weight: 900;
-  line-height: 0.8;
-  margin-bottom: 16px;
-  letter-spacing: -0.03em;
-}
-
-.stat-label {
-  font-size: clamp(2rem, 4vw, 4rem);
-  font-weight: 900;
-  text-transform: uppercase;
-  letter-spacing: -0.03em;
-  opacity: 0.7;
-}
-
-
-
 .intro-muted { opacity: 0.7; }
 .intro-shows { color: #fff; }
 .shows-label { line-height: 1; }
@@ -194,32 +171,6 @@ body {
   margin-left: 20px;
 }
 
-.historical-stats {
-  margin-top: 0;
-}
-
-.historical-stat {
-  margin-bottom: 30px;
-}
-
-.historical-number {
-  font-size: clamp(3rem, 8vw, 8rem);
-  font-weight: 900;
-  line-height: 0.8;
-  margin-bottom: 12px;
-  letter-spacing: -0.03em;
-}
-
-.historical-label {
-  font-size: clamp(1.2rem, 2.5vw, 2.5rem);
-  font-weight: 900;
-  text-transform: uppercase;
-  letter-spacing: -0.03em;
-  opacity: 0.6;
-}
-
-
-
 .metadata {
   background: var(--blue-darker);
   padding: 40px;
@@ -286,14 +237,6 @@ body {
   .data-section,
   .comparison-section {
     padding: 60px 20px;
-  }
-
-  .stat-item {
-    margin-bottom: 30px;
-  }
-
-  .historical-stat {
-    margin-bottom: 20px;
   }
 
   .year-selector {


### PR DESCRIPTION
## Summary
- Drop large attendance number and label from the current stats view
- Remove historical attendance figure and related CSS
- Simplify scripts to only update intro text and show counts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8d9032634832aa1472288cf98804c