### PR TITLE
Increase display font sizes for key headings

### DIFF
--- a/style.css
+++ b/style.css
@@ -44,7 +44,7 @@ body {
 }
 
 .intro-text {
-  font-size: clamp(2rem, 4vw, 4rem);
+  font-size: clamp(6rem, 12vw, 12rem);
   font-weight: 900;
   text-transform: uppercase;
   letter-spacing: -0.03em;
@@ -77,7 +77,7 @@ body {
 }
 
 .comparison-intro {
-  font-size: clamp(1.5rem, 3vw, 3rem);
+  font-size: clamp(3rem, 6vw, 6rem);
   font-weight: 900;
   text-transform: uppercase;
   letter-spacing: -0.03em;
@@ -124,7 +124,7 @@ body {
 }
 
 .shows-running-text {
-  font-size: clamp(1.5rem, 3vw, 3rem);
+  font-size: clamp(3rem, 6vw, 6rem);
   font-weight: 900;
   text-transform: uppercase;
   letter-spacing: -0.03em;
@@ -241,5 +241,14 @@ body {
 
   .year-selector {
     margin-left: 12px;
+  }
+
+  .intro-text {
+    font-size: clamp(3rem, 10vw, 8rem);
+  }
+
+  .comparison-intro,
+  .shows-running-text {
+    font-size: clamp(2rem, 8vw, 4rem);
   }
 }


### PR DESCRIPTION
## Summary
- enlarge `.intro-text`, `.comparison-intro`, and `.shows-running-text` font sizes for more prominent headings
- add responsive adjustments at `max-width: 768px` to keep text legible on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8df5f3a78832a8aa8256df7d3f178