### PR TITLE
Prevent line breaks in intro dashboard text

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,10 +82,10 @@
 
           document.getElementById("intro-text").innerHTML =
             `<span class="intro-faded">LAST WEEK THERE WERE</span> ` +
-            `<span class="intro-highlight">${data.showCount.toLocaleString()} SHOWS</span> ` +
+            `<span class="intro-highlight"><span class="no-wrap">${data.showCount.toLocaleString()}&nbsp;SHOWS</span></span> ` +
             `<span class="intro-faded">RUNNING AND</span> ` +
             `<span class="intro-highlight">${data.attendance.toLocaleString()}</span> ` +
-            `<span class="intro-faded">BUTTS IN SEATS</span>`;
+            `<span class="intro-faded"><span class="no-wrap">BUTTS&nbsp;IN&nbsp;SEATS</span></span>`;
 
           
 
@@ -127,10 +127,10 @@
 
         document.getElementById("intro-text").innerHTML =
           `<span class="intro-faded">LAST WEEK THERE WERE</span> ` +
-          `<span class="intro-highlight">${mockData.showCount.toLocaleString()} SHOWS</span> ` +
+          `<span class="intro-highlight"><span class="no-wrap">${mockData.showCount.toLocaleString()}&nbsp;SHOWS</span></span> ` +
           `<span class="intro-faded">RUNNING AND</span> ` +
           `<span class="intro-highlight">${mockData.attendance.toLocaleString()}</span> ` +
-          `<span class="intro-faded">BUTTS IN SEATS</span>`;
+          `<span class="intro-faded"><span class="no-wrap">BUTTS&nbsp;IN&nbsp;SEATS</span></span>`;
         
 
         document.getElementById("week-ending").textContent =

--- a/style.css
+++ b/style.css
@@ -61,6 +61,10 @@ body {
   opacity: 1;
 }
 
+.no-wrap {
+  white-space: nowrap;
+}
+
 .intro-muted { opacity: 0.7; }
 .intro-shows { color: #fff; }
 .shows-label { line-height: 1; }


### PR DESCRIPTION
## Summary
- ensure show count and label stay together with no-wrap spans and non-breaking spaces
- prevent "BUTTS IN SEATS" from breaking mid-phrase
- add `.no-wrap` CSS rule to enforce `white-space: nowrap`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8e03e2fa0832abc72b5d789e98977