### PR TITLE
Style intro text to fit viewport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.html
+++ b/index.html
@@ -82,10 +82,10 @@
 
           document.getElementById("intro-text").innerHTML =
             `<span class="intro-faded">LAST WEEK THERE WERE</span> ` +
-            `<span class="intro-highlight">${data.showCount.toLocaleString()} SHOWS</span> ` +
+            `<span class="intro-highlight no-wrap">${data.showCount.toLocaleString()} SHOWS</span><br>` +
             `<span class="intro-faded">RUNNING AND</span> ` +
-            `<span class="intro-highlight">${data.attendance.toLocaleString()}</span> ` +
-            `<span class="intro-faded">BUTTS IN SEATS</span>`;
+            `<span class="intro-highlight">${data.attendance.toLocaleString()}</span><br>` +
+            `<span class="intro-faded no-wrap">BUTTS IN SEATS</span>`;
 
           
 
@@ -127,10 +127,10 @@
 
         document.getElementById("intro-text").innerHTML =
           `<span class="intro-faded">LAST WEEK THERE WERE</span> ` +
-          `<span class="intro-highlight">${mockData.showCount.toLocaleString()} SHOWS</span> ` +
+          `<span class="intro-highlight no-wrap">${mockData.showCount.toLocaleString()} SHOWS</span><br>` +
           `<span class="intro-faded">RUNNING AND</span> ` +
-          `<span class="intro-highlight">${mockData.attendance.toLocaleString()}</span> ` +
-          `<span class="intro-faded">BUTTS IN SEATS</span>`;
+          `<span class="intro-highlight">${mockData.attendance.toLocaleString()}</span><br>` +
+          `<span class="intro-faded no-wrap">BUTTS IN SEATS</span>`;
         
 
         document.getElementById("week-ending").textContent =

--- a/style.css
+++ b/style.css
@@ -36,7 +36,7 @@ body {
 
 .data-section {
   flex: 1;
-  padding: 80px 40px;
+  padding: clamp(20px, 10vh, 80px) clamp(20px, 5vw, 40px);
   display: grid;
   grid-template-rows: auto 1fr auto;
   row-gap: 60px;
@@ -44,7 +44,7 @@ body {
 }
 
 .intro-text {
-  font-size: clamp(6rem, 12vw, 12rem);
+  font-size: clamp(2rem, min(10vw, 15vh), 12rem);
   font-weight: 900;
   text-transform: uppercase;
   letter-spacing: -0.03em;
@@ -59,6 +59,10 @@ body {
 .intro-highlight {
   color: #fff;
   opacity: 1;
+}
+
+.no-wrap {
+  white-space: nowrap;
 }
 
 .intro-muted { opacity: 0.7; }
@@ -236,7 +240,7 @@ body {
 @media (max-width: 768px) {
   .data-section,
   .comparison-section {
-    padding: 60px 20px;
+    padding: clamp(20px, 8vh, 60px) clamp(12px, 5vw, 20px);
   }
 
   .year-selector {
@@ -244,7 +248,7 @@ body {
   }
 
   .intro-text {
-    font-size: clamp(3rem, 10vw, 8rem);
+    font-size: clamp(2rem, min(8vw, 12vh), 8rem);
   }
 
   .comparison-intro,


### PR DESCRIPTION
## Summary
- Scale data section padding and headline font size with viewport units
- Keep "XX SHOWS" and "BUTTS IN SEATS" together using `no-wrap` spans
- Add mobile-friendly line breaks for the intro text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8dca60054832ab2e4b4ce64452b51