### PR TITLE
Remove loading screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,10 +14,9 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div id="loading" class="loading">DRUMROLL</div>
   <div id="error" class="error" hidden></div>
 
-  <div id="dashboard" hidden>
+  <div id="dashboard">
     <div class="main-screen">
       <section class="data-section">
         <p id="intro-text" class="intro-text"></p>
@@ -107,9 +106,6 @@
             "Week ending: " + data.weekEnding;
           document.getElementById("last-updated").textContent =
             "Last updated: " + data.lastUpdated;
-
-          document.getElementById("loading").remove();
-          document.getElementById("dashboard").hidden = false;
         } catch (err) {
           // Fallback to mock data if the API fails or times out
           console.log("API failed or timed out, using mock data:", err);
@@ -156,9 +152,6 @@
           "Week ending: " + mockData.weekEnding;
         document.getElementById("last-updated").textContent =
           "Last updated: " + mockData.lastUpdated;
-
-        document.getElementById("loading").remove();
-        document.getElementById("dashboard").hidden = false;
       }
 
       setupYearSelector() {
@@ -304,7 +297,6 @@
       }
 
       showError(message) {
-        document.getElementById("loading").remove();
         const err = document.getElementById("error");
         err.textContent = message;
         err.hidden = false;

--- a/style.css
+++ b/style.css
@@ -197,23 +197,6 @@ body {
   font-size: 1.5rem;
 }
 
-.loading {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: var(--blue);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: clamp(2rem, 6vw, 6rem);
-  font-weight: 900;
-  text-transform: uppercase;
-  letter-spacing: -0.03em;
-  text-align: center;
-}
-
 .error {
   background: #fff;
   color: var(--blue);


### PR DESCRIPTION
## Summary
- Drop DRUMROLL loading overlay so dashboard renders immediately
- Clean up script to stop referencing loading element and show errors directly
- Remove unused `.loading` styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8fd17b9a8832ab3cfb8181da0e4a7