### PR TITLE
Align count me in button on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -668,6 +668,11 @@ body::before {
     justify-content: center;
   }
   
+  /* Mobile: Left-align CTA under color picker */
+  .footer-left {
+    justify-content: flex-start;
+  }
+  
   .waitlist-cta {
     font-size: 18px;
     padding: 12px 24px;


### PR DESCRIPTION
Left-justify the "COUNT ME IN" button on mobile to align it under the color picker.

---
<a href="https://cursor.com/background-agent?bcId=bc-61217dd9-2752-4ac9-b36a-eb8bc7de3090">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-61217dd9-2752-4ac9-b36a-eb8bc7de3090">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

