### PR TITLE
Enlarge star icon on mobile buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -682,7 +682,7 @@ body::before {
   .shuffle-button {
     width: 44px;
     height: 44px;
-    font-size: 18px;
+    font-size: 24px;
   }
   
   .footer-logo {


### PR DESCRIPTION
Increase the font-size of the random color button's star symbol on mobile devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-7178b742-8847-42ad-a44c-0bed42b0fce0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7178b742-8847-42ad-a44c-0bed42b0fce0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

